### PR TITLE
fix: add CLAUDE_OPUS_4_5 enum and model normalization pattern

### DIFF
--- a/src/par_cc_usage/enums.py
+++ b/src/par_cc_usage/enums.py
@@ -25,6 +25,7 @@ class ModelType(str, Enum):
     CLAUDE_SONNET_4 = "sonnet-4"
     CLAUDE_SONNET_4_5 = "sonnet-4-5"
     CLAUDE_OPUS_4_1 = "opus-4-1"
+    CLAUDE_OPUS_4_5 = "opus-4-5"
     CLAUDE_HAIKU_4_5 = "haiku-4-5"
     UNKNOWN = "unknown"
 

--- a/src/par_cc_usage/json_models.py
+++ b/src/par_cc_usage/json_models.py
@@ -93,6 +93,8 @@ class MessageData(BaseModel):
         # Check for specific Claude 4.x models first (most specific patterns first)
         if "sonnet-4-5" in model_lower or "sonnet-4.5" in model_lower:
             return ModelType.CLAUDE_SONNET_4_5
+        if "opus-4-5" in model_lower or "opus-4.5" in model_lower:
+            return ModelType.CLAUDE_OPUS_4_5
         if "opus-4-1" in model_lower or "opus-4.1" in model_lower:
             return ModelType.CLAUDE_OPUS_4_1
         if "haiku-4-5" in model_lower or "haiku-4.5" in model_lower:
@@ -100,7 +102,7 @@ class MessageData(BaseModel):
         # Fallback to generic sonnet-4 for older Claude 4 models
         if "sonnet-4" in model_lower or "claude-sonnet-4" in model_lower:
             return ModelType.CLAUDE_SONNET_4
-        # Generic opus-4 pattern
+        # Generic opus-4 pattern (fallback for unknown opus-4.x versions)
         if "opus-4" in model_lower:
             return ModelType.OPUS
         return None


### PR DESCRIPTION
Bug: Model `claude-opus-4-5-20251101` was incorrectly normalized to generic `ModelType.OPUS` (value: "opus") instead of a specific enum. This caused incorrect pricing lookup since LiteLLM's pricing data for generic "opus" has $0.00/M for cache tokens, while Opus 4.5 should have $6.25/M for cache creation and $0.50/M for cache read.

Changes:
- Add `CLAUDE_OPUS_4_5 = "opus-4-5"` to ModelType enum in enums.py
- Add pattern match for `opus-4-5` and `opus-4.5` in json_models.py before the generic `opus-4` fallback

Impact: Users with Opus 4.5 usage will now see correct cost calculations instead of ~99% underreported costs.

fix #4 