### PR TITLE
feat(theme): add ANSI theme for terminal-native color palette support

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,9 @@ Claude Code usage tracking tool with real-time monitoring and analysis.
 - **Flexible output**: Table, JSON, and CSV export formats
 
 ### 🎨 Theme System
-- **Multiple built-in themes**: Choose from 5 carefully crafted themes for different preferences
+- **Multiple built-in themes**: Choose from 6 carefully crafted themes for different preferences
 - **Light and dark themes**: Options for both dark terminal and light terminal users
+- **Terminal-native ANSI theme**: Respects your terminal's color palette (great for Catppuccin, Dracula, etc.)
 - **Accessibility support**: High contrast theme meeting WCAG AAA standards
 - **Session-based overrides**: Temporarily change themes for individual command runs
 - **Rich color integration**: Semantic color system with consistent visual language
@@ -376,6 +377,7 @@ pccu monitor --show-pricing --config pricing-config.yaml  # Cost monitoring with
 # Theme customization
 pccu monitor --theme light  # Use light theme for this session
 pccu monitor --theme dark --show-sessions  # Dark theme with session details
+pccu monitor --theme ansi --show-sessions  # ANSI theme (respects terminal palette like Catppuccin)
 pccu monitor --theme accessibility --show-pricing  # High contrast theme with pricing
 pccu monitor --theme minimal --compact  # Minimal theme with compact display
 

--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ Claude Code usage tracking tool with real-time monitoring and analysis.
   - [Environment Variable Override](#environment-variable-override)
 - [Coming Soon](#coming-soon)
 - [What's New](#whats-new)
-  - [v0.10.1 - Windows Compatibility Fixes](#v0101---windows-compatibility-fixes)
-  - [v0.10.0 - Advanced Status Line Progress Bars & Performance](#v0100---advanced-status-line-progress-bars--performance)
-  - [v0.9.0 - Enhanced Status Line with Project Names](#v090---enhanced-status-line-with-project-names)
-  - [v0.8.0 - Claude Code Status Line Integration](#v080---claude-code-status-line-integration)
-  - [v0.7.0 - Enhanced Configuration Management](#v070---enhanced-configuration-management)
-  - [v0.6.0 - Usage Summary Analytics](#v060---usage-summary-analytics)
+  - [v0.17.0 - ANSI Theme & Dependency Updates](#v0170---ansi-theme--dependency-updates)
+  - [v0.16.0 - Last Message Time Display](#v0160---last-message-time-display)
+  - [v0.15.0 - Opus 4.5 Model Support](#v0150---opus-45-model-support)
+  - [v0.14.0 - Tool Usage Tracking](#v0140---tool-usage-tracking)
+  - [v0.13.0 - MCP Tool Differentiation](#v0130---mcp-tool-differentiation)
+  - [v0.12.0 - Theme System](#v0120---theme-system)
   - [older...](#older)
 - [Development](#development)
 
@@ -1298,6 +1298,20 @@ We're actively working on exciting new features to enhance your Claude Code moni
 **Want to contribute or request a feature?** Check out our [GitHub repository](https://github.com/paulrobello/par_cc_usage) or open an issue with your suggestions!
 
 ## What's New
+
+### v0.17.0 - ANSI Theme & Dependency Updates
+**New Feature**: Added terminal-native ANSI theme for users with custom terminal color palettes.
+
+#### ✨ New Features
+- **ANSI Theme**: New theme using standard ANSI color names instead of hex values
+  - Respects your terminal's configured color palette (Catppuccin, Dracula, Nord, Solarized, etc.)
+  - Use with `pccu monitor --theme ansi` or set as default with `pccu theme set ansi`
+  - Fixes garish colors when using custom terminal themes (issue #3)
+
+#### 📦 Dependency Updates
+- Updated all dependencies to latest versions (rich 14.3.1, typer 0.21.1, pydantic 2.12.5, etc.)
+
+Thanks to @tartansandal for the detailed investigation and fix suggestions!
 
 ### v0.16.0 - Last Message Time Display
 **New Feature**: Status line now supports showing the actual timestamp of the last message.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -87,7 +87,7 @@ display:
   time_format: 24h  # Time format: '12h' for 12-hour, '24h' for 24-hour
   display_mode: normal  # Display mode: 'normal' or 'compact'
   show_pricing: false  # Enable cost calculations and display (default: false)
-  theme: default  # Theme: 'default', 'dark', 'light', 'accessibility', or 'minimal'
+  theme: default  # Theme: 'default', 'dark', 'light', 'ansi', 'accessibility', or 'minimal'
   project_name_prefixes:  # Strip prefixes from project names for cleaner display
     - "-Users-"
     - "-home-"
@@ -284,7 +284,7 @@ model_multipliers:
 - `PAR_CC_USAGE_UPDATE_IN_PLACE`: Update display in place
 - `PAR_CC_USAGE_REFRESH_INTERVAL`: Display refresh interval
 - `PAR_CC_USAGE_TIME_FORMAT`: Time format ('12h' or '24h')
-- `PAR_CC_USAGE_THEME`: Theme name ('default', 'dark', 'light', 'accessibility', or 'minimal')
+- `PAR_CC_USAGE_THEME`: Theme name ('default', 'dark', 'light', 'ansi', 'accessibility', or 'minimal')
 - `PAR_CC_USAGE_PROJECT_NAME_PREFIXES`: Comma-separated list of prefixes to strip from project names
 - `PAR_CC_USAGE_AGGREGATE_BY_PROJECT`: Aggregate token usage by project instead of sessions ('true', '1', 'yes', 'on' for true)
 - `PAR_CC_USAGE_STATUSLINE_ENABLED`: Enable/disable Claude Code status line generation ('true', '1', 'yes', 'on' for true, default: true)

--- a/docs/DISPLAY_FEATURES.md
+++ b/docs/DISPLAY_FEATURES.md
@@ -382,6 +382,11 @@ PAR CC Usage includes a comprehensive theme system that allows you to customize 
 - **Colors**: Solarized Light palette (darker text, warm backgrounds)
 - **Best for**: Light terminals, bright environments
 
+**ANSI Theme**: Terminal-native theme using standard ANSI color names
+- **Use case**: Terminals with custom color palettes (Catppuccin, Dracula, Nord, etc.)
+- **Colors**: ANSI color names (green, cyan, yellow, red, magenta, blue)
+- **Best for**: Users who want the theme to respect their terminal's configured color palette
+
 **Accessibility Theme**: High contrast theme meeting WCAG AAA standards
 - **Use case**: Visual accessibility and screen readers
 - **Colors**: High contrast colors (black text on white background)
@@ -420,7 +425,7 @@ pccu monitor --theme light --show-sessions --show-pricing
 **Configuration File Setting:**
 ```yaml
 display:
-  theme: light  # Options: 'default', 'dark', 'light', 'accessibility', 'minimal'
+  theme: light  # Options: 'default', 'dark', 'light', 'ansi', 'accessibility', 'minimal'
 ```
 
 **Environment Variable:**
@@ -463,6 +468,7 @@ Themes apply to all visual elements:
 
 - **Light terminals**: Use `light` or `accessibility` themes
 - **Dark terminals**: Use `default` or `dark` themes
+- **Custom terminal palettes**: Use `ansi` theme (Catppuccin, Dracula, Nord, etc.)
 - **Accessibility needs**: Use `accessibility` theme for high contrast
 - **Professional environments**: Use `minimal` theme for clean appearance
 - **Testing themes**: Use `--theme` flag to test before setting as default

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -95,8 +95,9 @@ PAR CC Usage is a comprehensive monitoring solution designed specifically for tr
 - **Flexible output**: Table, JSON, and CSV export formats
 
 ## Theme System
-- **Multiple built-in themes**: Choose from 5 carefully crafted themes for different preferences
+- **Multiple built-in themes**: Choose from 6 carefully crafted themes for different preferences
 - **Light and dark themes**: Options for both dark terminal and light terminal users
+- **Terminal-native ANSI theme**: Respects your terminal's color palette (great for Catppuccin, Dracula, etc.)
 - **Accessibility support**: High contrast theme meeting WCAG AAA standards
 - **Session-based overrides**: Temporarily change themes for individual command runs
 - **Rich color integration**: Semantic color system with consistent visual language
@@ -199,6 +200,7 @@ PAR CC Usage is a comprehensive monitoring solution designed specifically for tr
 - **Default**: Original bright color scheme for dark terminals
 - **Dark**: Optimized colors for dark terminal backgrounds
 - **Light**: Solarized Light inspired palette for light terminals
+- **ANSI**: Terminal-native theme using ANSI color names (respects terminal palettes like Catppuccin)
 - **Accessibility**: High contrast theme meeting WCAG AAA standards
 - **Minimal**: Grayscale theme for distraction-free use
 

--- a/docs/USAGE_GUIDE.md
+++ b/docs/USAGE_GUIDE.md
@@ -517,6 +517,7 @@ pccu monitor --no-cache --snapshot
 
 ### Theme Selection
 - Use `light` theme for light terminals
+- Use `ansi` theme for custom terminal palettes (Catppuccin, Dracula, Nord, etc.)
 - Use `accessibility` theme for high contrast needs
 - Use `minimal` theme for distraction-free monitoring
 - Test themes with `--theme` flag before setting as default

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,16 +43,16 @@ keywords = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "rich>=13.7.0",
-    "typer>=0.9.0",
-    "pyyaml>=6.0.1",
-    "pydantic>=2.0.0",
-    "watchdog>=3.0.0",
-    "aiofiles>=23.0.0",
-    "pytz>=2023.3",
-    "requests>=2.31.0",
+    "rich>=14.3.1",
+    "typer>=0.21.1",
+    "pyyaml>=6.0.3",
+    "pydantic>=2.12.5",
+    "watchdog>=6.0.0",
+    "aiofiles>=25.1.0",
+    "pytz>=2025.2",
+    "requests>=2.32.5",
     "xdg-base-dirs>=6.0.2",
-    "aiohttp>=3.9.0",
+    "aiohttp>=3.13.3",
 ]
 
 [project.license]
@@ -75,17 +75,17 @@ pccu = "par_cc_usage.main:main"
 
 [dependency-groups]
 dev = [
-    "pyright>=1.1.402",
-    "types-pytz>=2024.2.0.20241221",
-    "types-requests>=2.32.0.20241016",
-    "types-pyyaml>=6.0.5.4",
-    "pre-commit>=4.2.0",
-    "ruff>=0.12.1",
-    "pytest>=8.4.1",
-    "pytest-cov>=6.2.1",
+    "pyright>=1.1.408",
+    "types-pytz>=2025.2.0.20250516",
+    "types-requests>=2.32.0.20250602",
+    "types-pyyaml>=6.0.12.20250516",
+    "pre-commit>=4.5.1",
+    "ruff>=0.14.14",
+    "pytest>=9.0.2",
+    "pytest-cov>=7.0.0",
     "hatchling>=1.27.0",
     "build>=1.2.2.post1",
-    "pytest-asyncio>=1.0.0",
+    "pytest-asyncio>=1.3.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/par_cc_usage/__init__.py
+++ b/src/par_cc_usage/__init__.py
@@ -1,3 +1,3 @@
 """PAR CC Usage - Claude Code usage tracking tool."""
 
-__version__ = "0.16.0"
+__version__ = "0.17.0"

--- a/src/par_cc_usage/enums.py
+++ b/src/par_cc_usage/enums.py
@@ -76,6 +76,7 @@ class ThemeType(str, Enum):
     DEFAULT = "default"
     DARK = "dark"
     LIGHT = "light"
+    ANSI = "ansi"
     ACCESSIBILITY = "accessibility"
     MINIMAL = "minimal"
 

--- a/src/par_cc_usage/theme.py
+++ b/src/par_cc_usage/theme.py
@@ -263,6 +263,71 @@ class ThemeManager:
             rich_theme=light_rich_theme,
         )
 
+        # ANSI theme (uses standard ANSI color names to respect terminal palettes)
+        # This theme works well with custom terminal themes like Catppuccin, Dracula, etc.
+        ansi_colors = ColorScheme(
+            success="green",
+            warning="yellow",
+            error="red",
+            info="blue",
+            primary="blue",
+            secondary="cyan",
+            accent="magenta",
+            border="yellow",
+            background="black",
+            text="white",
+            text_dim="dim",
+            token_count="yellow",
+            model_name="green",
+            project_name="cyan",
+            tool_usage="yellow",
+            tool_mcp="red",
+            tool_total="cyan",
+            cost="green",
+            progress_low="green",
+            progress_medium="yellow",
+            progress_high="yellow",
+            progress_critical="red",
+            burn_rate="cyan",
+            eta_normal="cyan",
+            eta_urgent="red",
+        )
+
+        ansi_rich_theme = Theme(
+            {
+                "success": ansi_colors.success,
+                "warning": ansi_colors.warning,
+                "error": ansi_colors.error,
+                "info": ansi_colors.info,
+                "primary": ansi_colors.primary,
+                "secondary": ansi_colors.secondary,
+                "accent": ansi_colors.accent,
+                "border": ansi_colors.border,
+                "text": ansi_colors.text,
+                "text_dim": ansi_colors.text_dim,
+                "token_count": ansi_colors.token_count,
+                "model_name": ansi_colors.model_name,
+                "project_name": ansi_colors.project_name,
+                "tool_usage": ansi_colors.tool_usage,
+                "tool_mcp": ansi_colors.tool_mcp,
+                "cost": ansi_colors.cost,
+                "progress_low": ansi_colors.progress_low,
+                "progress_medium": ansi_colors.progress_medium,
+                "progress_high": ansi_colors.progress_high,
+                "progress_critical": ansi_colors.progress_critical,
+                "burn_rate": ansi_colors.burn_rate,
+                "eta_normal": ansi_colors.eta_normal,
+                "eta_urgent": ansi_colors.eta_urgent,
+            }
+        )
+
+        self._themes[ThemeType.ANSI] = ThemeDefinition(
+            name="ANSI",
+            description="Terminal-native theme using ANSI color names (respects terminal palette)",
+            colors=ansi_colors,
+            rich_theme=ansi_rich_theme,
+        )
+
         # Accessibility theme (high contrast)
         accessibility_colors = ColorScheme(
             success="#00AA00",  # High contrast green

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -233,7 +233,7 @@ class TestThemeManager:
         manager = ThemeManager()
 
         themes = manager.list_themes()
-        assert len(themes) == 5  # All built-in themes
+        assert len(themes) == 6  # All built-in themes
 
         # Check all theme types present
         for theme_type in ThemeType:

--- a/uv.lock
+++ b/uv.lock
@@ -725,15 +725,15 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiofiles", specifier = ">=23.0.0" },
-    { name = "aiohttp", specifier = ">=3.9.0" },
-    { name = "pydantic", specifier = ">=2.0.0" },
-    { name = "pytz", specifier = ">=2023.3" },
-    { name = "pyyaml", specifier = ">=6.0.1" },
-    { name = "requests", specifier = ">=2.31.0" },
-    { name = "rich", specifier = ">=13.7.0" },
-    { name = "typer", specifier = ">=0.9.0" },
-    { name = "watchdog", specifier = ">=3.0.0" },
+    { name = "aiofiles", specifier = ">=25.1.0" },
+    { name = "aiohttp", specifier = ">=3.13.3" },
+    { name = "pydantic", specifier = ">=2.12.5" },
+    { name = "pytz", specifier = ">=2025.2" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "requests", specifier = ">=2.32.5" },
+    { name = "rich", specifier = ">=14.3.1" },
+    { name = "typer", specifier = ">=0.21.1" },
+    { name = "watchdog", specifier = ">=6.0.0" },
     { name = "xdg-base-dirs", specifier = ">=6.0.2" },
 ]
 
@@ -741,15 +741,15 @@ requires-dist = [
 dev = [
     { name = "build", specifier = ">=1.2.2.post1" },
     { name = "hatchling", specifier = ">=1.27.0" },
-    { name = "pre-commit", specifier = ">=4.2.0" },
-    { name = "pyright", specifier = ">=1.1.402" },
-    { name = "pytest", specifier = ">=8.4.1" },
-    { name = "pytest-asyncio", specifier = ">=1.0.0" },
-    { name = "pytest-cov", specifier = ">=6.2.1" },
-    { name = "ruff", specifier = ">=0.12.1" },
-    { name = "types-pytz", specifier = ">=2024.2.0.20241221" },
-    { name = "types-pyyaml", specifier = ">=6.0.5.4" },
-    { name = "types-requests", specifier = ">=2.32.0.20241016" },
+    { name = "pre-commit", specifier = ">=4.5.1" },
+    { name = "pyright", specifier = ">=1.1.408" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "ruff", specifier = ">=0.14.14" },
+    { name = "types-pytz", specifier = ">=2025.2.0.20250516" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20250516" },
+    { name = "types-requests", specifier = ">=2.32.0.20250602" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a new ANSI theme that uses standard ANSI color names instead of hex values. This allows the theme to respect the terminal's configured color palette, making it work beautifully with terminal themes like Catppuccin, Dracula, Nord, Solarized, etc.

## Problem

The DEFAULT theme uses hex colors (`#00FF00`, `#FFFF00`, etc.) which bypass the terminal palette and render as exact truecolor - looking garish in terminals with custom color schemes like Catppuccin Mocha.

As @tartansandal pointed out in #3:
> The monitor uses the theme system via `get_color()` which returns hex colors. In Kitty with Catppuccin Mocha, hex colors bypass the terminal palette entirely and render as exact truecolor - which looks garish.

## Solution

Add a new `ansi` theme that uses ANSI color names (`green`, `yellow`, `cyan`, etc.) instead of hex values. These names get remapped through the terminal palette, allowing the theme to look native in any terminal color scheme.

## Changes

- Add `ANSI` to `ThemeType` enum
- Add ANSI theme definition with ANSI color names in `theme.py`
- Update README with ANSI theme documentation
- Update `docs/CONFIGURATION.md` theme options
- Update `docs/DISPLAY_FEATURES.md` with ANSI theme details and best practices
- Update `docs/FEATURES.md` theme list
- Update `docs/USAGE_GUIDE.md` best practices
- Bump version to 0.17.0
- Update test to expect 6 themes

## Usage

```bash
# Use ANSI theme for terminal-native colors
pccu monitor --theme ansi --show-sessions

# Set as default
pccu theme set ansi
```

Fixes #3