### PR TITLE
fix: persist theme and display settings in config file

### DIFF
--- a/src/par_cc_usage/config.py
+++ b/src/par_cc_usage/config.py
@@ -665,9 +665,12 @@ def save_config(config: Config, config_file: Path) -> None:
             "refresh_interval": config.display.refresh_interval,
             "time_format": config.display.time_format.value,
             "project_name_prefixes": config.display.project_name_prefixes,
+            "aggregate_by_project": config.display.aggregate_by_project,
+            "show_tool_usage": config.display.show_tool_usage,
             "display_mode": config.display.display_mode.value,
             "show_pricing": config.display.show_pricing,
             "use_p90_limit": config.display.use_p90_limit,
+            "theme": config.display.theme.value,
         },
         "notifications": {
             "discord_webhook_url": config.notifications.discord_webhook_url,

--- a/src/par_cc_usage/main.py
+++ b/src/par_cc_usage/main.py
@@ -1041,6 +1041,9 @@ async def _monitor_async(  # noqa: C901
     # Apply temporary theme override if provided (before printing config)
     if theme is not None:
         apply_temporary_theme(theme)
+    else:
+        # Apply theme from config if no CLI override
+        apply_temporary_theme(config.display.theme)
 
     # Create themed console after theme is applied
     from .theme import create_themed_console
@@ -1336,6 +1339,9 @@ def list_usage(
     # Apply temporary theme override if provided
     if theme is not None:
         apply_temporary_theme(theme)
+    else:
+        # Apply theme from config if no CLI override
+        apply_temporary_theme(config.display.theme)
 
     # Create themed console after theme application
     from .theme import create_themed_console
@@ -2142,6 +2148,9 @@ def list_sessions(
         # Apply temporary theme override if provided
         if theme is not None:
             apply_temporary_theme(theme)
+        else:
+            # Apply theme from config if no CLI override
+            apply_temporary_theme(config.display.theme)
 
         console.print(f"[dim]Scanning projects in {config.projects_dir}...[/]")
 
@@ -2534,6 +2543,9 @@ async def _usage_summary_async(
     # Apply temporary theme override if provided
     if theme is not None:
         apply_temporary_theme(theme)
+    else:
+        # Apply theme from config if no CLI override
+        apply_temporary_theme(config.display.theme)
 
     # Create themed console after theme application
     from .theme import create_themed_console
@@ -2623,11 +2635,14 @@ def theme_command(
             console.print(f"    {theme_def.description}", style="dim")
 
     elif action == "current":
-        current_theme = theme_manager.get_current_theme()
+        # Load config to get the persisted theme setting
+        config = load_config(config_file)
+        theme_type = config.display.theme
+        theme_def = theme_manager.get_theme(theme_type)
         console.print(
-            f"Current theme: [bold]{current_theme.name}[/bold] ({theme_manager.get_current_theme_type().value})"
+            f"Current theme: [bold]{theme_def.name}[/bold] ({theme_type.value})"
         )
-        console.print(f"Description: {current_theme.description}")
+        console.print(f"Description: {theme_def.description}")
 
     elif action == "set":
         if not theme_name:


### PR DESCRIPTION
## Problem

The `save_config()` function was missing three `DisplayConfig` fields when saving to the configuration file, causing these settings to not persist across sessions:

- **`theme`**: Theme setting would revert to default after restart (reported issue)
- **`aggregate_by_project`**: Project aggregation setting wouldn't persist
- **`show_tool_usage`**: Tool usage display setting wouldn't persist

This meant that running `pccu theme set ansi` would appear to work, but `pccu theme current` would still show the default theme after restarting.

## Solution

Added all three missing fields to the `display` dictionary in `save_config()`:
- Line 667: `"aggregate_by_project": config.display.aggregate_by_project`
- Line 668: `"show_tool_usage": config.display.show_tool_usage`
- Line 671: `"theme": config.display.theme.value`

## Tests

Added comprehensive test coverage in `TestSaveConfig` class with 6 new tests:
1. Theme persistence (ANSI theme example)
2. All theme types persistence
3. `aggregate_by_project` setting persistence
4. `show_tool_usage` setting persistence
5. All display settings persistence (comprehensive)
6. Valid YAML structure verification

All 848 tests pass ✓

## Verification

Tested save/load roundtrip for all three previously missing fields:
- Theme setting now persists correctly
- `aggregate_by_project` setting now persists correctly
- `show_tool_usage` setting now persists correctly

---

## Update (2nd commit)

During testing, discovered two additional bugs that prevented the theme system from working completely:

**Bug 1: `theme current` command showed wrong theme**
- Was reading from ThemeManager's internal state (always DEFAULT)
- Fixed to load config file and return the persisted theme
- Now correctly shows the theme saved in config

**Bug 2: Theme not applied from config**
- Commands only applied theme when `--theme` CLI flag was provided
- Config theme was ignored, always fell back to DEFAULT
- Fixed in 4 commands: `monitor`, `list`, `list_sessions`, `usage_summary`
- Now applies theme from config when no CLI override provided

**Additional tests (7 new tests):**
- `TestThemeCurrentCommand`: Verify `theme current` reads from config
- `TestThemeApplicationFromConfig`: Verify theme applied from config
- `TestThemeSetAndCurrentWorkflow`: Verify complete workflow

Theme system now fully functional - themes persist, load, and apply correctly! 🎨
